### PR TITLE
Fix missing __SSE_4_1__

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,25 @@
+os:
+  - linux
+  - osx
+
+language: cpp
+
+env:
+  global:
+    # Needed for compatibility with GDAL on MacOS
+    - CXX="g++ -std=c++11"
+  jobs:
+    - CXXFLAGS=""
+    - DUMMY=""
+
+addons:
+  apt:
+    sources:
+      - sourceline: 'ppa:ubuntugis/ppa'
+    packages:
+      - gdal-bin
+      - libgdal-dev
+
+script:
+  - cd simd
+  - make

--- a/simd/LibSSE/LibSSE.cpp
+++ b/simd/LibSSE/LibSSE.cpp
@@ -63,7 +63,7 @@ __m256 atan2_256(
 
 
 //! Compute the x modulus y.
-#ifdef __SSE__
+#ifdef __SSE_4_1__
 __m128 modulus_128(
   const __m128& x,
   const __m128& y) {
@@ -76,7 +76,7 @@ __m128 modulus_128(
   n = _mm_round_ps(z / y, _MM_FROUND_TO_ZERO);
   return z - n * y;
 }
-#endif // __SSE__
+#endif // __SSE_4_1__
 #ifdef __AVX__
 __m256 modulus_256(
   const __m256& x,
@@ -94,7 +94,7 @@ __m256 modulus_256(
 
 
 //! Compute the exponential of a value.
-#ifdef __SSE__
+#ifdef __SSE_4_1__
 __m128 exp_128(
   const __m128& x) {
 
@@ -129,7 +129,7 @@ __m128 exp_128(
   //! Return the result
   return t * _mm_castsi128_ps(_mm_slli_epi32(emm0, 23));
 }
-#endif // __SSE__
+#endif // __SSE_4_1__
 #ifdef __AVX__
 __m256 exp_256(
   const __m256& x) {
@@ -176,7 +176,7 @@ __m256 exp_256(
 
 
 //! Compute the orientation bin.
-#ifdef __SSE__
+#ifdef __SSE_4_1__
 __m128 ori_to_bin_128(
   const __m128& ori,
   const int nbins) {
@@ -195,7 +195,7 @@ __m128 ori_to_bin_128(
   //! Return the modulo of it
   return val - xbins * _mm_round_ps(val / xbins, _MM_FROUND_TO_ZERO);
 }
-#endif // __SSE__
+#endif // __SSE_4_1__
 #ifdef __AVX__
 __m256 ori_to_bin_256(
   const __m256& ori,
@@ -215,7 +215,7 @@ __m256 ori_to_bin_256(
   //! Return the modulo of it
   return val - xbins * _mm256_round_ps(val / xbins, _MM_FROUND_TO_ZERO);
 }
-#endif // __SSE__
+#endif // __AVX__
 
 
 

--- a/simd/LibSSE/LibSSE.h
+++ b/simd/LibSSE/LibSSE.h
@@ -28,11 +28,11 @@ __m256 atan2_256(
 /**
  * @brief Compute the x modulus y.
  **/
- #ifdef __SSE__
+ #ifdef __SSE_4_1__
 __m128 modulus_128(
   const __m128& x,
   const __m128& y);
-#endif // __SSE__
+#endif // __SSE_4_1__
 #ifdef __AVX__
 __m256 modulus_256(
   const __m256& x,
@@ -62,10 +62,10 @@ inline __m256 hypot_256(
 /**
  * @brief Compute the exponential of a value.
  **/
- #ifdef __SSE__
+ #ifdef __SSE_4_1__
 __m128 exp_128(
   const __m128& x);
-#endif // __SSE__
+#endif // __SSE_4_1__
 #ifdef __AVX__
 __m256 exp_256(
   const __m256& x);
@@ -92,11 +92,11 @@ inline __m256 abs_256(
 /**
  * @brief Compute the orientation bin.
  **/
-#ifdef __SSE__
+#ifdef __SSE_4_1__
 __m128 ori_to_bin_128(
   const __m128& ori,
   const int nbins);
-#endif // __SSE__
+#endif // __SSE_4_1__
 #ifdef __AVX__
 __m256 ori_to_bin_256(
   const __m256& ori,

--- a/simd/LibSift/KeyPoint.cpp
+++ b/simd/LibSift/KeyPoint.cpp
@@ -319,7 +319,7 @@ void KeyPoint::extractFeatureVector(
   }
 #endif // __AVX__
 
-#ifdef __SSE__
+#ifdef __SSE_4_1__
   //! SSE version
   for (; n < nbPix - 4; n += 4) {
 
@@ -360,7 +360,7 @@ void KeyPoint::extractFeatureVector(
     _mm_storeu_ps(arr2 + n, applyMask_ps(m2, x0, x1 - abs_128(j0 - beta)));
     _mm_storeu_ps(arr3 + n, applyMask_ps(m3, x0, x1 - abs_128(j0 + x1 - beta)));
   }
-#endif // __SSE__
+#endif // __SSE_4_1__
 
   //! Normal version
   for (; n < nbPix; n++) {

--- a/simd/LibSift/LibSift.cpp
+++ b/simd/LibSift/LibSift.cpp
@@ -944,7 +944,7 @@ void Sift::accumulateOrientationHistogram(
       _mm256_storeu_ps(vg + n, ori_to_bin_256(ori, nbins));
     }
 #endif // __SSE__
-#ifdef __SSE__
+#ifdef __SSE_4_1__
     //! SSE version
     for (; sj <= sjMax - 4; sj += 4, n += 4) {
 
@@ -963,7 +963,7 @@ void Sift::accumulateOrientationHistogram(
       //! Determine the bin index in the circular histogram
       _mm_storeu_ps(vg + n, ori_to_bin_128(ori, nbins));
     }
-#endif // __SSE__
+#endif // __SSE_4_1__
 
     //! Normal version
     for (; sj <= sjMax; sj++, n++) {


### PR DESCRIPTION
This PR fixes some `#ifdef __SSE__` guards into `#ifdef __SSE_4_1__` for code blocks that use the [`_mm_round_ps` function which is defined only in `SSE 4.1`](https://software.intel.com/sites/landingpage/IntrinsicsGuide/#text=_mm_round_ps&expand=4757).

Some `#ifdef __SSE__` statements were also edited for code blocks that used functions defined inside `__SSE_4_1__`-guarded blocks.

A simple Travis CI config was also added to test the `make` on Linux/OSX with/without the default `CXXFLAGS`.

See:
- [a failing CI before commit 53c86c4](https://travis-ci.com/glostis/sift/builds/143738749)
- [a successful build after commit 53c86c4](https://travis-ci.com/glostis/sift/builds/143739152)